### PR TITLE
chore(deps): Update the runtime to 25.08

### DIFF
--- a/com.okta.developer.CLI.yaml
+++ b/com.okta.developer.CLI.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: com.okta.developer.CLI
 runtime: org.freedesktop.Sdk
-runtime-version: '21.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: okta
 modules:


### PR DESCRIPTION
Sdk 21.08 is outdated and no longer receives security updates.
This PR updates the Sdk to 25.08, which still is supported